### PR TITLE
Parse Origin server load header by intermedia server (Varnish cache).

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Example playback in DASH-IF reference player:
 | Streaming format 	| sf 	| CMSD-Static 	| Token - one of [d,h,s,o] 	| The streaming format defines the current response.<br><br>d = MPEG DASH<br><br>h = HTTP Live Streaming (HLS)<br><br>s = Smooth Streaming<br><br>o = other<br><br>If the streaming format being returned is unknown, then this key MUST NOT be used. 	|
 | Encoded bitrate 	| br 	| CMSD-Static 	| Integer [Kilobit per second] 	| The encoded bitrate of the audio or video object being requested. If the instantaneous bitrate varies over the duration of the object, the peak value should be communicated. 	|
 | Request ID 	| rid 	| CMSD-Static 	| String 	| A request ID, issued by the player or an upstream component, that is received by the origin when processing inbound content requests. 	|
-
+| CPU load 	| cpu 	| CMSD-Dynamic 	| Token - one of [l,m,h] 	| The server load when serving the content. Bucketed in one of three levels - low, medium and high. 	|
 
 ### Possible alternatives for implementing unsupported Key-Value Pairs from CMSD
 

--- a/docker/apache-origin-cmsd/conf.d/origin.conf
+++ b/docker/apache-origin-cmsd/conf.d/origin.conf
@@ -75,8 +75,10 @@ LogFormat '${LOG_FORMAT}' log_format
 
   # Streaming format (sf)
   Header merge CMSD-Static sf=d "expr=%{REQUEST_URI} =~ m#^/.*.[dash|mpd]$#"
-  # For the load of CMSD we could use one of the following
-  Header set CMSD-Load "load=%l, idle=%i%%, busy=%b%%"
+  
+  # Set current Apache2 web server load in X-Origin-Load Header
+  # More info: https://httpd.apache.org/docs/current/mod/mod_headers.html 
+  Header set X-Origin-Load "load=%l, idle=%i%%, busy=%b%%"
 
   # Add encoded bitarate based on %{REQUEST_URI} and only set the VENCODE var 
   # when is presenetd in the REQUEST_URI variable


### PR DESCRIPTION
Added `%b` value from [mod_headers](https://httpd.apache.org/docs/current/mod/mod_headers.html) in `CMSD-Dynamic: cpu=...`.The intermediate server (Varnish Cache) parses the internal HTTP response Header `X-Origin-Load` generated by backend (Origin server) to a [l,m,h] token.